### PR TITLE
fix: OgpWrapperをPanda CSSからインラインスタイルに戻す

### DIFF
--- a/src/components/layout/Ogp/OgpWrapper.tsx
+++ b/src/components/layout/Ogp/OgpWrapper.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react'
-import { styled } from 'styled-system/jsx'
 
 type Props = {
   children: ReactNode
@@ -7,46 +6,54 @@ type Props = {
 
 export const OgpWrapper = ({ children }: Props) => {
   return (
-    <styled.div
-      w='100%'
-      h='100%'
-      display='flex'
-      alignItems='center'
-      justifyContent='center'
-      background='linear-gradient(to right, {colors.brand.primary} 0%, {colors.brand.dark} 100%)'
-      p='2xl'
-      fontSize='72px'
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'linear-gradient(to right, #3F4C9C 0%, #2d1b69 100%)',
+        padding: '24px',
+        fontSize: '72px',
+      }}
     >
-      <styled.div
-        w='100%'
-        h='100%'
-        color='base'
-        bg='bg.base'
-        display='flex'
-        justifyContent='space-between'
-        flexDirection='column'
-        borderRadius='lg'
-        p='40px'
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          color: '#191C37',
+          background: '#F8F9FE',
+          display: 'flex',
+          justifyContent: 'space-between',
+          flexDirection: 'column',
+          borderRadius: '16px',
+          padding: '40px',
+        }}
       >
         {children}
-        <styled.div w='100%' display='flex'>
-          <styled.div
-            w='100%'
-            display='flex'
-            justifyContent='flex-start'
-            alignItems='center'
-            fontSize='56px'
-            gap='20px'
+        <div style={{ width: '100%', display: 'flex' }}>
+          <div
+            style={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'flex-start',
+              alignItems: 'center',
+              fontSize: '56px',
+              gap: '20px',
+            }}
           >
-            <styled.div
-              display='flex'
-              borderRadius='full'
-              overflow='hidden'
-              boxShadow='0 0 0 3px {colors.brand.light}'
-              alignItems='center'
-              ml='md'
-              w='56px'
-              h='56px'
+            <div
+              style={{
+                display: 'flex',
+                borderRadius: '9999px',
+                overflow: 'hidden',
+                boxShadow: '0 0 0 3px #5B6FD8',
+                alignItems: 'center',
+                marginLeft: '8px',
+                width: '56px',
+                height: '56px',
+              }}
             >
               <img
                 src='https://avatars.githubusercontent.com/u/43092452?v=4'
@@ -55,11 +62,11 @@ export const OgpWrapper = ({ children }: Props) => {
                 height={56}
                 style={{ borderRadius: '9999px' }}
               />
-            </styled.div>
-            <styled.span pb='5px'>Relu</styled.span>
-          </styled.div>
-        </styled.div>
-      </styled.div>
-    </styled.div>
+            </div>
+            <span style={{ paddingBottom: '5px' }}>Relu</span>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- OgpWrapperコンポーネントをPanda CSSのstyledコンポーネントからインラインスタイルに修正
- next/ogのImageResponseではPanda CSSが使用できないため、正しい実装に戻した
- createArticleMetadataでOGP画像URLを自動設定
- opengraph-image.tsxでNext.js 16の非同期params仕様に対応

## 背景
### 問題1: Panda CSS移行時のデグレ
fdd8bd8のコミット(Panda CSS移行)で、OgpWrapperを誤ってPanda CSSのstyledに変換してしまっていた。
next/ogのImageResponseは独自のインラインスタイルシステムを使用するため、Panda CSSは動作しない。

### 問題2: Next.js 16アップグレード時の対応漏れ
b9e2740のコミット(Next.js 16.0.1へのアップグレード)で、動的ルートの`params`がPromiseになったが、
opengraph-image.tsxが古い同期的な書き方のまま残っていた。

### 問題3: OGP画像メタデータの未設定
記事詳細ページでog:imageメタタグが生成されていなかった。

## 変更内容
### OgpWrapper.tsx
- `styled.div`を通常の`div`に変更
- すべてのスタイルをインラインスタイルオブジェクトで記述
- カラー値をPanda CSS設定から対応する実際のカラーコードに変換

### opengraph-image.tsx
- `params`の型を`Promise<{ postId: string }>`に変更
- `params`を`await`して`postId`を取得

### metadata.ts
- `createArticleMetadata`でOGP画像URLを自動設定
- 記事詳細ページのOGP画像が正しく表示されるように修正

## Test plan
- [x] OGP画像が正しく表示されることを確認
- [x] グラデーション背景が表示されることを確認
- [x] アイコンとテキストが正しくレンダリングされることを確認
- [x] 記事詳細ページのOGP画像メタデータが設定されることを確認
- [x] Next.js 16の非同期paramsでエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)