### PR TITLE
fix: OGP画像のメタデータ設定とNext.js 16のparams対応

### DIFF
--- a/src/app/post/[postId]/opengraph-image.tsx
+++ b/src/app/post/[postId]/opengraph-image.tsx
@@ -9,9 +9,10 @@ export const runtime = 'edge'
 export const alt = 'Reluの投稿記事'
 export const contentType = 'image/png'
 
-export default async function Image({ params }: { params: { postId: string } }) {
+export default async function Image({ params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params
   const font = await fetchGoogleFonts(OGP_FONT)
-  const post = await fetchPost(params.postId)
+  const post = await fetchPost(postId)
 
   return new ImageResponse(<OgpWrapper>{post.title.slice(0, MAX_OGP_TEXT_LENGTH)}</OgpWrapper>, {
     ...OGP_IMAGE_SIZE,

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -58,10 +58,13 @@ export const createArticleMetadata = (
   description: string,
   path: string,
 ): Metadata => {
+  const ogImageUrl = `${SITE_CONFIG.url}${path}/opengraph-image`
+
   return createMetadata({
     title,
     description,
     path,
     type: 'article',
+    images: ogImageUrl,
   })
 }


### PR DESCRIPTION
## Summary
- createArticleMetadataでOGP画像URLを自動設定し、og:imageメタタグを生成
- opengraph-image.tsxでNext.js 16の非同期params仕様に対応
- 記事詳細ページでOGP画像が正しく表示されるように修正

## 背景
### 問題1: OGP画像メタデータの未設定
記事詳細ページでog:imageメタタグが生成されていなかったため、SNSでリンクをシェアした際に
「metaタグにog:imageプロパティが存在しないため、シェア画像プレビューを表示できません」
というエラーが発生していた。

### 問題2: Next.js 16アップグレード時の対応漏れ
b9e2740のコミット(Next.js 16.0.1へのアップグレード)で、動的ルートの`params`がPromiseになったが、
opengraph-image.tsxが古い同期的な書き方のまま残っていた。

```
Error: Route "/post/[postId]/opengraph-image" used `params.postId`. 
`params` is a Promise and must be unwrapped with `await`
```

## 変更内容
### metadata.ts ([metadata.ts:61](src/utils/metadata.ts#L61))
- `createArticleMetadata`でOGP画像URLを自動設定
- `${SITE_CONFIG.url}${path}/opengraph-image` 形式でURLを生成
- Next.jsの`opengraph-image.tsx`が生成する画像URLと一致

### opengraph-image.tsx ([opengraph-image.tsx:12-13](src/app/post/[postId]/opengraph-image.tsx#L12-L13))
- `params`の型を`Promise<{ postId: string }>`に変更
- `params`を`await`して`postId`を取得
- Next.js 16の非同期params仕様に準拠

## Test plan
- [x] 記事詳細ページのHTMLにog:imageメタタグが含まれることを確認
- [x] OGP画像URLが正しく生成されることを確認
- [x] Next.js 16の非同期paramsでエラーが発生しないことを確認
- [x] SNSシェア時にOGP画像プレビューが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)